### PR TITLE
Fix dependencies

### DIFF
--- a/modules/format/package.json
+++ b/modules/format/package.json
@@ -22,9 +22,6 @@
     "type-check": "upbin tsc --noEmit",
     "watch": "upbin tsc --declaration --watch"
   },
-  "dependencies": {
-    "deepmerge": "^2.2.1"
-  },
   "devDependencies": {
     "upbin": "^0.8.1"
   },

--- a/modules/retriever/package.json
+++ b/modules/retriever/package.json
@@ -23,10 +23,10 @@
     "watch": "upbin tsc --declaration --watch"
   },
   "dependencies": {
-    "@sp2/format": "~1.2.2"
+    "@sp2/format": "~1.2.2",
+    "fast-deep-equal": "^2.0.1"
   },
   "devDependencies": {
-    "fast-deep-equal": "^2.0.1",
     "upbin": "^0.8.1"
   },
   "publishConfig": {


### PR DESCRIPTION
`@sp2/retriever` should contain `fast-deep-equal` in `"dependencies"` field, not in `"depDependencies"`.