### PR TITLE
fix(format): Allow accesses to optional props in DocumentPath

### DIFF
--- a/modules/format/src/common/bound-document-path.ts
+++ b/modules/format/src/common/bound-document-path.ts
@@ -1,5 +1,15 @@
 import { createDocumentPath, getNestedValueWithoutType } from "./document-path";
 
+export type DeepRequired<T> = T extends Array<infer InnerType>
+  ? DeepRequiredArray<InnerType>
+  : T extends number | string | boolean | Function | RegExp // TODO: Add more native types
+  ? T
+  : T extends Object
+  ? { [K in keyof T]-?: DeepRequired<T[K]> }
+  : T;
+
+interface DeepRequiredArray<T> extends Array<DeepRequired<T>> {}
+
 export type BoundDocumentPathOfDepth1<
   T extends Object,
   K1 extends keyof T
@@ -137,6 +147,32 @@ export type BoundDocumentPath<
   K8,
   K9,
   K10
+> = RawBoundDocumentPath<
+  DeepRequired<T>,
+  K1,
+  K2,
+  K3,
+  K4,
+  K5,
+  K6,
+  K7,
+  K8,
+  K9,
+  K10
+>;
+
+type RawBoundDocumentPath<
+  T,
+  K1,
+  K2,
+  K3,
+  K4,
+  K5,
+  K6,
+  K7,
+  K8,
+  K9,
+  K10
 > = K1 extends keyof T
   ? K2 extends keyof T[K1]
     ? K3 extends keyof T[K1][K2]
@@ -182,7 +218,11 @@ export type BoundDocumentPath<
     : BoundDocumentPathOfDepth1<T, K1>
   : string;
 
-export interface BoundDocumentPathCreator<T> {
+export type BoundDocumentPathCreator<T> = RawBoundDocumentPathCreator<
+  DeepRequired<T>
+>;
+
+interface RawBoundDocumentPathCreator<T> {
   <K1 extends keyof T>(k1: K1): BoundDocumentPathOfDepth1<T, K1>;
   <K1 extends keyof T, K2 extends keyof T[K1]>(
     k1: K1,
@@ -320,6 +360,20 @@ export function $path<T>(): BoundDocumentPathCreator<T> {
 }
 
 export type NestedValue<
+  T,
+  K1,
+  K2,
+  K3,
+  K4,
+  K5,
+  K6,
+  K7,
+  K8,
+  K9,
+  K10
+> = RawNestedValue<DeepRequired<T>, K1, K2, K3, K4, K5, K6, K7, K8, K9, K10>;
+
+export type RawNestedValue<
   T,
   K1,
   K2,

--- a/modules/format/src/updating/bound-create-update-operation.ts
+++ b/modules/format/src/updating/bound-create-update-operation.ts
@@ -117,7 +117,7 @@ type ValueOf<OP extends UpdateOperator, V> = BoundUpdateOperandItemValue<
 export type UpdateOperationCreator<
   OP extends UpdateOperator,
   T
-> = RawUpdateOperationCreator<OP, DeepRequired<T>>;
+> = RawUpdateOperationCreator<OP, DeepRequired<T> | T>;
 
 export interface RawUpdateOperationCreator<OP extends UpdateOperator, T> {
   <K1 extends keyof T>(

--- a/modules/format/src/updating/bound-create-update-operation.ts
+++ b/modules/format/src/updating/bound-create-update-operation.ts
@@ -10,6 +10,7 @@ import {
   BoundDocumentPathOfDepth7,
   BoundDocumentPathOfDepth8,
   BoundDocumentPathOfDepth9,
+  DeepRequired,
   NestedValue,
 } from "../common/bound-document-path";
 import {
@@ -113,7 +114,12 @@ type ValueOf<OP extends UpdateOperator, V> = BoundUpdateOperandItemValue<
   RegularUpdateValue<OP>
 >[OP];
 
-export interface UpdateOperationCreator<OP extends UpdateOperator, T> {
+export type UpdateOperationCreator<
+  OP extends UpdateOperator,
+  T
+> = RawUpdateOperationCreator<OP, DeepRequired<T>>;
+
+export interface RawUpdateOperationCreator<OP extends UpdateOperator, T> {
   <K1 extends keyof T>(
     docPath: BoundDocumentPathOfDepth1<T, K1>,
     value: ValueOf<OP, T[K1]>

--- a/modules/format/test/common/bound-document-path.test.ts
+++ b/modules/format/test/common/bound-document-path.test.ts
@@ -16,11 +16,43 @@ describe("$path", () => {
     assert(createDocumentPath("foo", "bar", 1) === "foo.bar[1]");
     assert(createDocumentPath("foo", "bar", 1, "name") === "foo.bar[1].name");
   });
+
+  it("returns a function which allows optional documentPath", () => {
+    type TargetObject = { foo?: { bar?: { name?: string }[] } };
+    const createDocumentPath = $path<TargetObject>();
+    assert(createDocumentPath("foo") === "foo");
+    assert(createDocumentPath("foo", "bar") === "foo.bar");
+    assert(createDocumentPath("foo", "bar", 1) === "foo.bar[1]");
+    assert(createDocumentPath("foo", "bar", 1, "name") === "foo.bar[1].name");
+  });
 });
 
 describe("getNestedValue", () => {
-  it("returns a function creating documentPath of target object passed via type parameter", () => {
+  it("returns a function getting nested value of given object at given documentPath", () => {
     type TargetObject = { foo: { bar: { name: string }[] } };
+    const p = $path<TargetObject>();
+    const obj: TargetObject = { foo: { bar: [{ name: "John" }] } };
+
+    assert.deepStrictEqual(getNestedValue(obj, p("foo")), {
+      bar: [{ name: "John" }],
+    });
+
+    assert.deepStrictEqual(getNestedValue(obj, p("foo", "bar")), [
+      { name: "John" },
+    ]);
+
+    assert.deepStrictEqual(getNestedValue(obj, p("foo", "bar", 0)), {
+      name: "John",
+    });
+
+    assert.deepStrictEqual(
+      getNestedValue(obj, p("foo", "bar", 0, "name")),
+      "John"
+    );
+  });
+
+  it("returns a function which accepts optional documentPaths", () => {
+    type TargetObject = { foo?: { bar?: { name?: string }[] } };
     const p = $path<TargetObject>();
     const obj: TargetObject = { foo: { bar: [{ name: "John" }] } };
 

--- a/modules/format/test/updating/bound-create-update-operation.test.ts
+++ b/modules/format/test/updating/bound-create-update-operation.test.ts
@@ -22,8 +22,28 @@ describe("$op", () => {
       });
     });
 
+    it("contains $set function accepting accesses to optional props", () => {
+      type TargetObject = { foo?: { bar?: { name?: string }[] } };
+      const { $set } = $op<TargetObject>();
+      const $docPath = $path<TargetObject>();
+      const operation = $set($docPath("foo", "bar", 0, "name"), "John");
+      assert.deepStrictEqual(operation, {
+        $set: { "foo.bar[0].name": "John" },
+      });
+    });
+
     it("contains $inc function", () => {
       type TargetObject = { foo: { bar: { age: number } } };
+      const { $inc } = $op<TargetObject>();
+      const $docPath = $path<TargetObject>();
+      const operation = $inc($docPath("foo", "bar", "age"), 1);
+      assert.deepStrictEqual(operation, {
+        $inc: { "foo.bar.age": 1 },
+      });
+    });
+
+    it("contains $inc function accepting accesses to optional props", () => {
+      type TargetObject = { foo?: { bar?: { age?: number } } };
       const { $inc } = $op<TargetObject>();
       const $docPath = $path<TargetObject>();
       const operation = $inc($docPath("foo", "bar", "age"), 1);
@@ -112,6 +132,16 @@ describe("$op", () => {
       });
     });
 
+    it("contains $push function accepting accesses to optional props", () => {
+      type TargetObject = { foo?: { bar?: { age?: number }[] } };
+      const { $push } = $op<TargetObject>();
+      const $docPath = $path<TargetObject>();
+      const operation = $push($docPath("foo", "bar"), { age: 30 });
+      assert.deepStrictEqual(operation, {
+        $push: { "foo.bar": { age: 30 } },
+      });
+    });
+
     it("contains $currentDate function", () => {
       type TargetObject = { foo: { bar: { date: number } } };
       const { $currentDate } = $op<TargetObject>();
@@ -136,6 +166,16 @@ describe("$op", () => {
 
     it("contains $unset function", () => {
       type TargetObject = { foo: { bar: { baz: number } } };
+      const { $unset } = $op<TargetObject>();
+      const $docPath = $path<TargetObject>();
+      const operation = $unset($docPath("foo", "bar", "baz"), "");
+      assert.deepStrictEqual(operation, {
+        $unset: { "foo.bar.baz": "" },
+      });
+    });
+
+    it("contains $unset function accepting accesses to optional props", () => {
+      type TargetObject = { foo?: { bar?: { baz?: number } } };
       const { $unset } = $op<TargetObject>();
       const $docPath = $path<TargetObject>();
       const operation = $unset($docPath("foo", "bar", "baz"), "");


### PR DESCRIPTION
fix #13

- DocumentPath
- NestedValue
- UpdateOperationCreator

are now conscious of optional properties.