### PR TITLE
Fix(updater): Add fast-deep-equal to dependencies

### DIFF
--- a/modules/updater/package.json
+++ b/modules/updater/package.json
@@ -24,7 +24,8 @@
   },
   "dependencies": {
     "@sp2/format": "^1.4.1",
-    "@sp2/retriever": "^1.4.1"
+    "@sp2/retriever": "^1.4.1",
+    "fast-deep-equal": "^2.0.1"
   },
   "devDependencies": {
     "upbin": "^0.8.1"


### PR DESCRIPTION
This incompleteness was masked because `fast-deep-equal` was in the dependencies in dependencies
(@sp2/retriever).