### PR TITLE
1.6.2

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
     "modules/*"
   ],
   "npmClient": "yarn",
-  "version": "1.6.0-alpha.1"
+  "version": "1.6.0"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
     "modules/*"
   ],
   "npmClient": "yarn",
-  "version": "1.6.0"
+  "version": "1.6.1"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
     "modules/*"
   ],
   "npmClient": "yarn",
-  "version": "1.6.1"
+  "version": "1.6.2"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
     "modules/*"
   ],
   "npmClient": "yarn",
-  "version": "1.6.0-alpha.0"
+  "version": "1.6.0-alpha.1"
 }

--- a/modules/format/README.md
+++ b/modules/format/README.md
@@ -1,5 +1,5 @@
 # @sp2/format
 
-This library provides fundamental types and functions used in [@sp2/updater](https://github.com/phenyl-js/sp2/blob/master/modules/updater) and [@sp2/retriever](https://github.com/phenyl-js/sp2/blob/master/modules/retriever).
+This library provides fundamental types and functions used in [@sp2/updater](https://github.com/phenyl/sp2/blob/master/modules/updater) and [@sp2/retriever](https://github.com/phenyl/sp2/blob/master/modules/retriever).
 
 This is for internal use and in most cases you don't have to directly access to this library.

--- a/modules/format/package.json
+++ b/modules/format/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sp2/format",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "@sp2/format provides fundamental types and functions used in sp2.",
   "bugs": "https://github.com/phenyl/sp2/issues",
   "repository": "phenyl/sp2",

--- a/modules/format/package.json
+++ b/modules/format/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sp2/format",
-  "version": "1.6.0-alpha.0",
+  "version": "1.6.0-alpha.1",
   "description": "@sp2/format provides fundamental types and functions used in sp2.",
   "bugs": "https://github.com/phenyl/sp2/issues",
   "repository": "phenyl/sp2",

--- a/modules/format/package.json
+++ b/modules/format/package.json
@@ -2,8 +2,8 @@
   "name": "@sp2/format",
   "version": "1.6.0-alpha.0",
   "description": "@sp2/format provides fundamental types and functions used in sp2.",
-  "bugs": "https://github.com/phenyl-js/sp2/issues",
-  "repository": "phenyl-js/sp2",
+  "bugs": "https://github.com/phenyl/sp2/issues",
+  "repository": "phenyl/sp2",
   "license": "Apache-2.0",
   "author": "Shin Suzuki <shinout310@gmail.com>",
   "files": [

--- a/modules/format/package.json
+++ b/modules/format/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sp2/format",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "@sp2/format provides fundamental types and functions used in sp2.",
   "bugs": "https://github.com/phenyl/sp2/issues",
   "repository": "phenyl/sp2",

--- a/modules/format/package.json
+++ b/modules/format/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sp2/format",
-  "version": "1.6.0-alpha.1",
+  "version": "1.6.0",
   "description": "@sp2/format provides fundamental types and functions used in sp2.",
   "bugs": "https://github.com/phenyl/sp2/issues",
   "repository": "phenyl/sp2",

--- a/modules/main/README.md
+++ b/modules/main/README.md
@@ -1,7 +1,8 @@
 # sp2
+
 `sp2` is a set of JavaScript modules using syntax for **State-operating Procedures with Portability**.
 Portability means that procedures are expressed by JSON data. This makes procedures portable and applicable over different environments.
 
 This concept of "portable operation" is inspired by MongoDB. In fact, sp2 uses similar syntaxes as MongoDB's operations in its modules.
 
-See more details [here](https://github.com/phenyl-js/sp2).
+See more details [here](https://github.com/phenyl/sp2).

--- a/modules/main/package.json
+++ b/modules/main/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sp2",
-  "version": "1.6.0-alpha.1",
+  "version": "1.6.0",
   "description": "Immutable updater of objects using JSON operation.",
   "bugs": "https://github.com/phenyl/sp2/issues",
   "repository": "phenyl/sp2",
@@ -30,9 +30,9 @@
     "type-check": "upbin tsc --noEmit"
   },
   "dependencies": {
-    "@sp2/format": "^1.6.0-alpha.1",
-    "@sp2/retriever": "^1.6.0-alpha.1",
-    "@sp2/updater": "^1.6.0-alpha.1"
+    "@sp2/format": "^1.6.0",
+    "@sp2/retriever": "^1.6.0",
+    "@sp2/updater": "^1.6.0"
   },
   "devDependencies": {
     "upbin": "0.8.2"

--- a/modules/main/package.json
+++ b/modules/main/package.json
@@ -2,8 +2,8 @@
   "name": "sp2",
   "version": "1.6.0-alpha.0",
   "description": "Immutable updater of objects using JSON operation.",
-  "bugs": "https://github.com/phenyl-js/sp2/issues",
-  "repository": "phenyl-js/sp2",
+  "bugs": "https://github.com/phenyl/sp2/issues",
+  "repository": "phenyl/sp2",
   "keywords": [
     "immutable",
     "mutable",

--- a/modules/main/package.json
+++ b/modules/main/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sp2",
-  "version": "1.6.0-alpha.0",
+  "version": "1.6.0-alpha.1",
   "description": "Immutable updater of objects using JSON operation.",
   "bugs": "https://github.com/phenyl/sp2/issues",
   "repository": "phenyl/sp2",
@@ -30,9 +30,9 @@
     "type-check": "upbin tsc --noEmit"
   },
   "dependencies": {
-    "@sp2/format": "^1.6.0-alpha.0",
-    "@sp2/retriever": "^1.6.0-alpha.0",
-    "@sp2/updater": "^1.6.0-alpha.0"
+    "@sp2/format": "^1.6.0-alpha.1",
+    "@sp2/retriever": "^1.6.0-alpha.1",
+    "@sp2/updater": "^1.6.0-alpha.1"
   },
   "devDependencies": {
     "upbin": "0.8.2"

--- a/modules/main/package.json
+++ b/modules/main/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sp2",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Immutable updater of objects using JSON operation.",
   "bugs": "https://github.com/phenyl/sp2/issues",
   "repository": "phenyl/sp2",
@@ -30,9 +30,9 @@
     "type-check": "upbin tsc --noEmit"
   },
   "dependencies": {
-    "@sp2/format": "^1.6.0",
-    "@sp2/retriever": "^1.6.0",
-    "@sp2/updater": "^1.6.0"
+    "@sp2/format": "^1.6.1",
+    "@sp2/retriever": "^1.6.1",
+    "@sp2/updater": "^1.6.1"
   },
   "devDependencies": {
     "upbin": "0.8.2"

--- a/modules/main/package.json
+++ b/modules/main/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sp2",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Immutable updater of objects using JSON operation.",
   "bugs": "https://github.com/phenyl/sp2/issues",
   "repository": "phenyl/sp2",
@@ -30,9 +30,9 @@
     "type-check": "upbin tsc --noEmit"
   },
   "dependencies": {
-    "@sp2/format": "^1.6.1",
-    "@sp2/retriever": "^1.6.1",
-    "@sp2/updater": "^1.6.1"
+    "@sp2/format": "^1.6.2",
+    "@sp2/retriever": "^1.6.2",
+    "@sp2/updater": "^1.6.2"
   },
   "devDependencies": {
     "upbin": "0.8.2"

--- a/modules/retriever/package.json
+++ b/modules/retriever/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sp2/retriever",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "@sp2/retriever retrieves objects in array by MongoDB-like find operations.",
   "bugs": "https://github.com/phenyl/sp2/issues",
   "repository": "phenyl/sp2",
@@ -23,7 +23,7 @@
     "watch": "upbin tsc --declaration --watch"
   },
   "dependencies": {
-    "@sp2/format": "^1.6.1",
+    "@sp2/format": "^1.6.2",
     "fast-deep-equal": "^3.0.0"
   },
   "devDependencies": {

--- a/modules/retriever/package.json
+++ b/modules/retriever/package.json
@@ -2,8 +2,8 @@
   "name": "@sp2/retriever",
   "version": "1.6.0-alpha.0",
   "description": "@sp2/retriever retrieves objects in array by MongoDB-like find operations.",
-  "bugs": "https://github.com/phenyl-js/sp2/issues",
-  "repository": "phenyl-js/sp2",
+  "bugs": "https://github.com/phenyl/sp2/issues",
+  "repository": "phenyl/sp2",
   "license": "Apache-2.0",
   "author": "Shin Suzuki <shinout310@gmail.com>",
   "files": [

--- a/modules/retriever/package.json
+++ b/modules/retriever/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sp2/retriever",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "@sp2/retriever retrieves objects in array by MongoDB-like find operations.",
   "bugs": "https://github.com/phenyl/sp2/issues",
   "repository": "phenyl/sp2",
@@ -23,7 +23,7 @@
     "watch": "upbin tsc --declaration --watch"
   },
   "dependencies": {
-    "@sp2/format": "^1.6.0",
+    "@sp2/format": "^1.6.1",
     "fast-deep-equal": "^3.0.0"
   },
   "devDependencies": {

--- a/modules/retriever/package.json
+++ b/modules/retriever/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sp2/retriever",
-  "version": "1.6.0-alpha.0",
+  "version": "1.6.0-alpha.1",
   "description": "@sp2/retriever retrieves objects in array by MongoDB-like find operations.",
   "bugs": "https://github.com/phenyl/sp2/issues",
   "repository": "phenyl/sp2",
@@ -23,7 +23,7 @@
     "watch": "upbin tsc --declaration --watch"
   },
   "dependencies": {
-    "@sp2/format": "^1.6.0-alpha.0",
+    "@sp2/format": "^1.6.0-alpha.1",
     "fast-deep-equal": "^3.0.0"
   },
   "devDependencies": {

--- a/modules/retriever/package.json
+++ b/modules/retriever/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sp2/retriever",
-  "version": "1.6.0-alpha.1",
+  "version": "1.6.0",
   "description": "@sp2/retriever retrieves objects in array by MongoDB-like find operations.",
   "bugs": "https://github.com/phenyl/sp2/issues",
   "repository": "phenyl/sp2",
@@ -23,7 +23,7 @@
     "watch": "upbin tsc --declaration --watch"
   },
   "dependencies": {
-    "@sp2/format": "^1.6.0-alpha.1",
+    "@sp2/format": "^1.6.0",
     "fast-deep-equal": "^3.0.0"
   },
   "devDependencies": {

--- a/modules/updater/package.json
+++ b/modules/updater/package.json
@@ -2,8 +2,8 @@
   "name": "@sp2/updater",
   "version": "1.6.0-alpha.0",
   "description": "@sp2/updater provides core update() function of sp2.",
-  "bugs": "https://github.com/phenyl-js/sp2/issues",
-  "repository": "phenyl-js/sp2",
+  "bugs": "https://github.com/phenyl/sp2/issues",
+  "repository": "phenyl/sp2",
   "license": "Apache-2.0",
   "author": "Shin Suzuki <shinout310@gmail.com>",
   "files": [

--- a/modules/updater/package.json
+++ b/modules/updater/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sp2/updater",
-  "version": "1.6.0-alpha.1",
+  "version": "1.6.0",
   "description": "@sp2/updater provides core update() function of sp2.",
   "bugs": "https://github.com/phenyl/sp2/issues",
   "repository": "phenyl/sp2",
@@ -23,8 +23,8 @@
     "watch": "upbin tsc --declaration --watch"
   },
   "dependencies": {
-    "@sp2/format": "^1.6.0-alpha.1",
-    "@sp2/retriever": "^1.6.0-alpha.1",
+    "@sp2/format": "^1.6.0",
+    "@sp2/retriever": "^1.6.0",
     "fast-deep-equal": "^3.0.0"
   },
   "devDependencies": {

--- a/modules/updater/package.json
+++ b/modules/updater/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sp2/updater",
-  "version": "1.6.0-alpha.0",
+  "version": "1.6.0-alpha.1",
   "description": "@sp2/updater provides core update() function of sp2.",
   "bugs": "https://github.com/phenyl/sp2/issues",
   "repository": "phenyl/sp2",
@@ -23,8 +23,8 @@
     "watch": "upbin tsc --declaration --watch"
   },
   "dependencies": {
-    "@sp2/format": "^1.6.0-alpha.0",
-    "@sp2/retriever": "^1.6.0-alpha.0",
+    "@sp2/format": "^1.6.0-alpha.1",
+    "@sp2/retriever": "^1.6.0-alpha.1",
     "fast-deep-equal": "^3.0.0"
   },
   "devDependencies": {

--- a/modules/updater/package.json
+++ b/modules/updater/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sp2/updater",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "@sp2/updater provides core update() function of sp2.",
   "bugs": "https://github.com/phenyl/sp2/issues",
   "repository": "phenyl/sp2",
@@ -23,8 +23,8 @@
     "watch": "upbin tsc --declaration --watch"
   },
   "dependencies": {
-    "@sp2/format": "^1.6.0",
-    "@sp2/retriever": "^1.6.0",
+    "@sp2/format": "^1.6.1",
+    "@sp2/retriever": "^1.6.1",
     "fast-deep-equal": "^3.0.0"
   },
   "devDependencies": {

--- a/modules/updater/package.json
+++ b/modules/updater/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sp2/updater",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "@sp2/updater provides core update() function of sp2.",
   "bugs": "https://github.com/phenyl/sp2/issues",
   "repository": "phenyl/sp2",
@@ -23,8 +23,8 @@
     "watch": "upbin tsc --declaration --watch"
   },
   "dependencies": {
-    "@sp2/format": "^1.6.1",
-    "@sp2/retriever": "^1.6.1",
+    "@sp2/format": "^1.6.2",
+    "@sp2/retriever": "^1.6.2",
     "fast-deep-equal": "^3.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "1",
   "private": true,
   "description": "Immutable updater of objects using JSON operation. This is the monorepo root and `modules/main` package is the one that is published.",
-  "homepage": "https://github.com/phenyl-js/sp2#readme",
-  "bugs": "https://github.com/phenyl-js/sp2/issues",
-  "repository": "phenyl-js/sp2",
+  "homepage": "https://github.com/phenyl/sp2#readme",
+  "bugs": "https://github.com/phenyl/sp2/issues",
+  "repository": "phenyl/sp2",
   "license": "Apache-2.0",
   "author": "Shin Suzuki <shinout310@gmail.com>",
   "engines": {


### PR DESCRIPTION
# CHANGELOG

Stop using `DeepRequired<T>` to avoid TypeScript error: `excessively deep and possibly infinite` #55