### PR TITLE
feat: add type default document type of bind operator

### DIFF
--- a/modules/format/src/common/bound-document-path.ts
+++ b/modules/format/src/common/bound-document-path.ts
@@ -1,4 +1,5 @@
 import { createDocumentPath, getNestedValueWithoutType } from "./document-path";
+import { DefaultDocumentType } from "./default-document-type";
 
 type Attribute = string | number;
 type DocumentPathSegment<K extends Attribute> = K extends string
@@ -163,7 +164,7 @@ export type BoundDocumentPath<
     : BoundDocumentPathOfDepth1<T, K1>
   : string;
 
-export interface BoundDocumentPathCreator<T> {
+export interface BoundDocumentPathCreator<T = DefaultDocumentType> {
   <K1 extends Extract<keyof T, Attribute>>(k1: K1): BoundDocumentPathOfDepth1<
     T,
     K1

--- a/modules/format/src/common/default-document-type.ts
+++ b/modules/format/src/common/default-document-type.ts
@@ -1,0 +1,7 @@
+/**
+ * This interface can be augmented by users to add default types for the root document path when
+ * using `sp2`.
+ * Use module augmentation to append your own type definition in a your_custom_type.d.ts file.
+ * https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation
+ */
+export interface DefaultDocumentType {}

--- a/modules/format/src/index.ts
+++ b/modules/format/src/index.ts
@@ -4,6 +4,7 @@ export {
   BoundDocumentPath,
   BoundDocumentPathCreator,
 } from "./common/bound-document-path";
+export { DefaultDocumentType } from "./common/default-document-type";
 export {
   $op,
   BoundGeneralUpdateOperation,
@@ -88,9 +89,7 @@ export {
 
 export { createUpdateOperation } from "./updating/create-update-operation";
 export { mergeUpdateOperations } from "./updating/merge-update-operations";
-export {
-  normalizeQueryCondition,
-} from "./retrieving/normalize-query-condition";
+export { normalizeQueryCondition } from "./retrieving/normalize-query-condition";
 export { visitFindOperation } from "./retrieving/visit-find-operation";
 export { visitUpdateOperation } from "./updating/visit-update-operation";
 export { toMongoFindOperation } from "./retrieving/to-mongo-find-operation";

--- a/modules/format/src/updating/bind.ts
+++ b/modules/format/src/updating/bind.ts
@@ -7,6 +7,7 @@ import { createDocumentPath } from "../common/document-path";
 import { mergeUpdateOperations } from "./merge-update-operations";
 import { retargetOperation } from "./retarget-operation";
 import { updateOpearationCreator } from "./bound-create-update-operation";
+import { DefaultDocumentType } from "../common/default-document-type";
 
 const updateOperationCreatorAndDocumentPathCreatorAndRetargetFunctionAndMergeFunction = Object.assign(
   {},
@@ -19,8 +20,8 @@ const updateOperationCreatorAndDocumentPathCreatorAndRetargetFunctionAndMergeFun
   }
 );
 
-export function $bind<T>(): {
-  [OP in UpdateOperator]: UpdateOperationCreator<OP, T>
+export function $bind<T = DefaultDocumentType>(): {
+  [OP in UpdateOperator]: UpdateOperationCreator<OP, T>;
 } & {
   $docPath: BoundDocumentPathCreator<T>;
   $merge: BoundMergeOperations<T>;

--- a/modules/format/src/updating/bound-merge-update-operations.ts
+++ b/modules/format/src/updating/bound-merge-update-operations.ts
@@ -1,3 +1,4 @@
+import { DefaultDocumentType } from "../common/default-document-type";
 import {
   BoundGeneralUpdateOperation,
   BoundNonBreakingUpdateOperation,
@@ -5,12 +6,12 @@ import {
 
 import { mergeUpdateOperations } from "./merge-update-operations";
 
-export function $merge<T>(): BoundMergeOperations<T> {
+export function $merge<T = DefaultDocumentType>(): BoundMergeOperations<T> {
   // @ts-ignore surpress for typing.
   return mergeUpdateOperations;
 }
 
-export interface BoundMergeOperations<T> {
+export interface BoundMergeOperations<T = DefaultDocumentType> {
   (
     ...operationList: BoundNonBreakingUpdateOperation<T>[]
   ): BoundNonBreakingUpdateOperation<T>;

--- a/modules/format/src/updating/bound-retarget-operation.ts
+++ b/modules/format/src/updating/bound-retarget-operation.ts
@@ -1,4 +1,5 @@
 import { BoundDocumentPath, NestedValue } from "../common/bound-document-path";
+import { DefaultDocumentType } from "../common/default-document-type";
 import {
   BoundGeneralUpdateOperation,
   BoundNonBreakingUpdateOperation,
@@ -11,7 +12,7 @@ export function $retarget<T>(): BoundRetarget<T> {
   return retargetOperation;
 }
 
-export interface BoundRetarget<T> {
+export interface BoundRetarget<T = DefaultDocumentType> {
   <
     U extends NestedValue<T, K1, K2, K3, K4, K5, K6, K7, K8>,
     K1,

--- a/modules/main/index.ts
+++ b/modules/main/index.ts
@@ -59,6 +59,7 @@ export {
   validateUpdateOperation,
   visitFindOperation,
   visitUpdateOperation,
+  DefaultDocumentType,
 } from "@sp2/format";
 
 export { checkCondition, retrieve } from "@sp2/retriever";


### PR DESCRIPTION
Add default-document-type.ts.
This type definition file adds default types to functions like $bind and $merge.
It is also possible to override it in your-type.d.ts.

usage

```ts
// example.d.ts
import 'sp2';
import type { MyDocumentPath } from './my/document/path';

declare module 'sp2' {
  interface DefaultDocumentType extends MyDocumentPath {}
}

```